### PR TITLE
Automate gh-pages update from main branch

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -1,0 +1,30 @@
+name: Update gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ Existen muchas rutas de aprendizaje en internet, algunas incluso son generadas p
 
 Existen muchos recursos que tal vez no alcance a recopilar en este repositorio, te agradecería mucho si ayudas a contribuir incluyéndolos, para que podamos construir una guía que sea de ayuda para todos.
 
+## Actualización Automática de Contenido en gh-pages
+
+Para garantizar que el contenido de `gh-pages` esté siempre actualizado con el contenido más reciente de la rama principal, se ha implementado un proceso de actualización automática. Este proceso se lleva a cabo mediante el archivo de flujo de trabajo `update-gh-pages.yml` ubicado en el directorio `.github/workflows`. Cada vez que se realiza un push a la rama principal, este flujo de trabajo se activa automáticamente, construyendo y desplegando el sitio a `gh-pages`, asegurando así que el contenido esté sincronizado y actualizado.


### PR DESCRIPTION
Implements an automated process for updating `gh-pages` with the latest content from the main branch.

- **Adds a new workflow file**: A file named `update-gh-pages.yml` is added to the `.github/workflows` directory. This workflow triggers on push events to the main branch, automating the build and deployment of the site to `gh-pages`.
- **Updates README.md**: The documentation now includes a section that details the automated process for keeping `gh-pages` updated with the main branch. This ensures users are aware of the synchronization mechanism in place.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanessamarely/recursos-frontend?shareId=01f184f6-8aeb-4517-8fdd-4795e9283b0d).