### PR TITLE
Update workflow to replicate markdown files without Node.js

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -12,19 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: .
+          keep_files: true
+          force_orphan: true


### PR DESCRIPTION
Updates the GitHub Actions workflow to replicate markdown files to `gh-pages` without using Node.js.

- Removes the steps related to setting up Node.js, installing dependencies, and building from the `.github/workflows/update-gh-pages.yml` file.
- Adds a new deployment step that directly copies all files from the main branch to `gh-pages`, ensuring existing files are kept and the deployment is forced as an orphan to avoid conflicts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanessamarely/recursos-frontend?shareId=74537309-55f2-4e12-b266-f63c457317da).