### PR TITLE
Add book suggestions about free JavaScript books

### DIFF
--- a/Libros-JavaScript.md
+++ b/Libros-JavaScript.md
@@ -1,0 +1,20 @@
+# Libros de JavaScript
+
+## Libros en Español
+
+- [JavaScript, ¡Inspírate!](https://leanpub.com/javascript-inspirate)
+- [Cómo ser front-end sin fallar en el intento](https://www.amazon.com/C%C3%B3mo-ser-front-end-fallar-intento-ebook/dp/B08GL1ZZCQ)
+
+## Libros en Inglés
+
+- [You Don't Know JS Yet](https://github.com/getify/You-Dont-Know-JS) by Kyle Simpson
+- [Eloquent JavaScript](https://eloquentjavascript.net/) by Marijn Haverbeke
+- [JavaScript: The Good Parts](https://www.oreilly.com/library/view/javascript-the-good/9780596517748/) by Douglas Crockford
+
+## Libros de Axel Rauschmayer
+
+- [Exploring ES6](https://exploringjs.com/es6/)
+- [Exploring ES2016 and ES2017](https://exploringjs.com/es2016-es2017/)
+- [Exploring ES2018](https://exploringjs.com/es2018/)
+- [Exploring ES2019](https://exploringjs.com/es2019/)
+- [Exploring ES2020](https://exploringjs.com/es2020/)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Existen muchas rutas de aprendizaje en internet, algunas incluso son generadas p
 ## [Otros](otros.md)
 
 ## [Libros](Libros.md)
+### [Libros de JavaScript](Libros-JavaScript.md)
 
 
 # Soporte a los recursos 🆘


### PR DESCRIPTION
Add a markdown file with book suggestions about free JavaScript books in Spanish and English, including Axel Rauschmayer's books, and update the main index in `README.md`.

* Create a new file `Libros-JavaScript.md` with book suggestions about free JavaScript books in Spanish and English, including Axel Rauschmayer's books.
* Update `README.md` to include a link to `Libros-JavaScript.md` in the main index under the "Libros" section.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vanessamarely/recursos-frontend/tree/main?shareId=946226e6-c1e7-494e-b610-315bc3872500).